### PR TITLE
Allow options to be set using a callback

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -6,6 +6,10 @@ class Functions {
   public static function deploy()
   {
     $url = option('f-mahler.kirby-vercel.deployurl');
+    if (is_callable($url)) {
+      $url = $url();
+    }
+
     $handle = curl_init();
     curl_setopt($handle, CURLOPT_URL, $url);
     curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
@@ -18,7 +22,15 @@ class Functions {
 
   public static function latest() {
     $token = option('f-mahler.kirby-vercel.token');
+    if (is_callable($token)) {
+      $token = $token();
+    }
+
     $projectid = option('f-mahler.kirby-vercel.projectid');
+    if (is_callable($projectid)) {
+      $projectid = $projectid();
+    }
+
     $url = 'https://api.vercel.com/v5/now/deployments?limit=1&projectId=' . $projectid;
     $authorization = "Authorization: Bearer " . $token;
     $handle = curl_init();

--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -1,6 +1,10 @@
 <?php
 
 $names = option('f-mahler.kirby-vercel.hooks');
+if (is_callable($names)) {
+    $names = $names();
+}
+
 $timestamphooks = [
 	'site.update:after', 'site.changeTitle:after',
 	'page.update:after', 'page.create:after', 'page.delete:after', 'page.changeTitle:after',


### PR DESCRIPTION
I wanted to use an .env file to store the Vercel credentials using this plugin:

https://github.com/bnomei/kirby3-dotenv

Since plugins are not loaded when the config.php is loaded, I could not load the env file in the config file. This PR makes it possible to use callbacks for the option values that your plugin uses.