### PR TITLE
If no option hooks are set, use an empty array

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -1,6 +1,6 @@
 <?php
 
-$names = option('f-mahler.kirby-vercel.hooks');
+$names = option('f-mahler.kirby-vercel.hooks') ?? []; // If no hooks are set, use an empty array
 if (is_callable($names)) {
     $names = $names();
 }


### PR DESCRIPTION
Hey! if no f-mahler.kirby-vercel.hooks/names are set we need to set to an empty array.
